### PR TITLE
 Enhancements to support new use cases. Documentation fixes.

### DIFF
--- a/my_perftest_qos_profiles.xml
+++ b/my_perftest_qos_profiles.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+
+<!--
+(c) 2005-2017  Copyright, Real-Time Innovations, Inc. All rights reserved.
+Subject to Eclipse Public License v1.0; see LICENSE.md for details.
+-->
+
+<!--
+This file contains the QoS configurations used by the RTI PerfTest, a
+performance test for measuring the latency of the middleware at different
+throughput levels.
+
+The format of this file is described in the RTI Connext Core Libraries
+and Utilities User's Manual in the chapter titled "Configuring QoS with XML."
+-->
+
+<!--
+This qos file is not used by default.
+
+It shows an example of defining a custom qos library "MyPerftestQosLibrary"
+that extends the perftest_qos_profiles.xml (the default settings used by 
+perftest) to further customize the qos policies.
+
+
+To use this QoS file:
+
+export NDDS_QOS_PROFILES=<path_to>/perftest_qos_profiles.xml
+
+Publisher(s):
+
+ 	perftest_cpp -qosprofile my_perftest_qos_profiles.xml 
+                 -qosLibrary MyPerftestQosLibrary 
+                 -pub
+
+
+Subscriber(s):
+
+ 	perftest_cpp -qosprofile my_perftest_qos_profiles.xml 
+                 -qosLibrary MyPerftestQosLibrary 
+                 -sub
+-->
+
+<dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://community.rti.com/schema/5.3.0/rti_dds_profiles.xsd">
+
+  <qos_library name="MyPerftestQosLibrary">
+
+    <!-- ================================================================= -->
+    <!-- Transport QoS Profile                                          -->
+    <!-- ================================================================= -->
+
+	<qos_profile name="TransportQos" 
+				 base_name="PerftestQosLibrary::TransportQos">
+	</qos_profile>
+    
+    <!-- ================================================================= -->
+    <!-- Throughput QoS Profile                                            -->
+    <!-- ================================================================= -->
+
+    <qos_profile name="ThroughputQos" 
+    			 base_name="PerftestQosLibrary::ThroughputQos">
+    </qos_profile>
+
+
+    <!-- ================================================================= -->
+    <!-- Latency QoS Profile                                               -->
+    <!-- ================================================================= -->
+
+    <qos_profile name="LatencyQos" 
+    			 base_name="PerftestQosLibrary::LatencyQos">
+    </qos_profile>
+
+
+    <!-- ================================================================= -->
+    <!-- Throughput QoS Profile (positive ACKs disabled)                   -->
+    <!-- ================================================================= -->
+
+    <qos_profile name="NoAckThroughputQos" 
+    			 base_name="PerftestQosLibrary::NoAckThroughputQos">
+    </qos_profile>
+
+
+    <!-- ================================================================= -->
+    <!-- Latency QoS Profile (positive ACKs disabled)                      -->
+    <!-- ================================================================= -->
+
+    <qos_profile name="NoAckLatencyQos" 
+    			 base_name="PerftestQosLibrary::NoAckLatencyQos">
+    </qos_profile>
+
+
+    <!-- ================================================================= -->
+    <!-- Announcement QoS Profile                                          -->
+    <!-- ================================================================= -->
+
+    <qos_profile name="AnnouncementQos" 
+    			 base_name="PerftestQosLibrary::AnnouncementQos">
+    </qos_profile>
+
+  </qos_library>
+</dds>

--- a/perftest_qos_profiles.xml
+++ b/perftest_qos_profiles.xml
@@ -42,7 +42,8 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
       <participant_qos>
         <!-- === Participant Configuration: ================================ 
 
-        The base configuration of the DomainParticipant object.
+        The base configuration of the DomainParticipant object, excluding 
+        transport configuration.
 
         This element corresponds to the DomainParticipantQos type, which is described
         in detail in the API Reference HTML documentation. Each child element corresponds
@@ -88,93 +89,9 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
           -->
           <contentfilter_property_max_length>512</contentfilter_property_max_length>
         </resource_limits>
-          
-        <!-- 
-        Specifies which built-in transports are used.
-
-        Three different transport plug-ins are built into the Connext core
-        libraries (for most supported target platforms): UDPv4, shared memory, and
-        UDPv6.
-        -->
-        <transport_builtin>
-          <mask>UDPv4</mask>
-        </transport_builtin>
         
         <property>
           <value>
-            <!-- 
-            Specifies the configuration to be used with the UDPv4 built-in transport.
-            -->
-            <element>
-              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
-              <value>65536</value>
-            </element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
-              <value>524288</value>
-            </element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
-              <value>2097152</value>
-            </element>
-
-            <!-- 
-            Specifies the configuration to be used with the SHMEM built-in transport.
-
-            Important: The commented setting is configured automatically within the 
-            source code. The default value of _DataLen is 100.
-              
-            Value set in the source code:
-            
-            <element>
-              <name>dds.transport.shmem.builtin.received_message_count_max</name>
-              <value>2097152/_DataLen</value>
-            </element>
-            -->
-            <element>
-              <name>dds.transport.shmem.builtin.parent.message_size_max</name>
-              <value>65536</value>
-            </element>
-            <element>
-              <name>dds.transport.shmem.builtin.receive_buffer_size</name>
-              <value>2097152</value>
-            </element>
-
-            <!-- 
-            Specifies the configuration to be used with the TCP transport.
-            
-            If TCP is enabled using -useTcpOnly, the load_plugins property is set
-            within the source code.
-            
-            Important: nddstransporttcp.dll is located in NDDSHOME/lib/<architecture>.
-            That folder must be added to the PATH on Windows systems and LD_LIBRARY_PATH
-            on UNIX-based systems in order to load this library properly. If you are 
-            compiling PerfTest using CSHARP, you must also add the folder 
-            NDDSHOME/lib/i86Win32VS<version> or NDDSHOME/lib/x64Win64VS<version> depending
-            on the machine.
-            
-            <element>
-              <name>dds.transport.load_plugins</name>
-              <value>dds.transport.TCPv4.tcp1</value>
-            </element>
-            -->
-            <element>
-              <name>dds.transport.TCPv4.tcp1.library</name>
-              <value>nddstransporttcp</value>
-            </element>
-            <element>
-              <name>dds.transport.TCPv4.tcp1.create_function</name>
-              <value>NDDS_Transport_TCPv4_create</value>
-            </element>
-            <element>
-              <name>dds.transport.TCPv4.tcp1.disable_nagle</name>
-              <value>1</value>
-            </element>
-            <element>
-              <name>dds.transport.TCPv4.tcp1.parent.message_size_max</name>
-              <value>65536</value>
-            </element>
-
             <!-- Defining flow controller 10Gbps. This will not enable it. -->
             <element>
               <name>dds.flow_controller.token_bucket.10Gbps.token_bucket.max_tokens</name>
@@ -380,7 +297,116 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
       </datareader_qos>
       
     </qos_profile>
+        
+    <!-- ================================================================= -->
+    <!-- Transport QoS Profile                                          -->
+    <!-- ================================================================= -->
 
+    <!--
+    This profile is used by the test harness for the creating the 
+    DomainParticipant used for the test.
+    -->
+	<qos_profile name="TransportQos" base_name="BaseProfileQos">
+
+      <participant_qos>
+        <!-- === Participant Transport Configuration: ========================== 
+
+        The transport configuration of the DomainParticipant object.
+        -->
+          
+        <!-- 
+        Specifies which built-in transports are used.
+
+        Three different transport plug-ins are built into the Connext core
+        libraries (for most supported target platforms): UDPv4, shared memory, and
+        UDPv6.
+        -->
+        <transport_builtin>
+          <mask>UDPv4</mask>
+        </transport_builtin>
+	        
+        <property>
+          <value>
+            <!-- 
+            Specifies the configuration to be used with the UDPv4 built-in transport.
+            -->
+            <element>
+              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
+              <value>65536</value>
+            </element>
+            <element>
+              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
+              <value>524288</value>
+            </element>
+            <element>
+              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
+              <value>2097152</value>
+            </element>
+
+            <!-- 
+            Specifies the configuration to be used with the SHMEM built-in transport.
+
+            Important: The commented setting is configured automatically within the 
+            source code. The default value of _DataLen is 100.
+              
+            Value set in the source code:
+            
+            <element>
+              <name>dds.transport.shmem.builtin.received_message_count_max</name>
+              <value>2097152/_DataLen</value>
+            </element>
+            -->
+            <element>
+              <name>dds.transport.shmem.builtin.parent.message_size_max</name>
+              <value>65536</value>
+            </element>
+            <element>
+              <name>dds.transport.shmem.builtin.receive_buffer_size</name>
+              <value>2097152</value>
+            </element>
+
+            <!-- 
+            Specifies the configuration to be used with the TCP transport.
+            
+            If TCP is enabled using -enableTcp, the load_plugins property is set
+            within the source code.
+            
+            Important: nddstransporttcp.dll is located in NDDSHOME/lib/<architecture>.
+            That folder must be added to the PATH on Windows systems and LD_LIBRARY_PATH
+            on UNIX-based systems in order to load this library properly. If you are 
+            compiling PerfTest using CSHARP, you must also add the folder 
+            NDDSHOME/lib/i86Win32VS<version> or NDDSHOME/lib/x64Win64VS<version> depending
+            on the machine.
+            
+            <element>
+              <name>dds.transport.load_plugins</name>
+              <value>dds.transport.TCPv4.tcp1</value>
+            </element>
+            -->
+            <element>
+              <name>dds.transport.TCPv4.tcp1.library</name>
+              <value>nddstransporttcp</value>
+            </element>
+            <element>
+              <name>dds.transport.TCPv4.tcp1.create_function</name>
+              <value>NDDS_Transport_TCPv4_create</value>
+            </element>
+            <element>
+              <name>dds.transport.TCPv4.tcp1.disable_nagle</name>
+              <value>1</value>
+            </element>
+            <element>
+              <name>dds.transport.TCPv4.tcp1.parent.message_size_max</name>
+              <value>65536</value>
+            </element>
+            
+          </value>
+        </property>
+
+      </participant_qos>
+          
+	</qos_profile>
+    
     <!-- ================================================================= -->
     <!-- Throughput QoS Profile                                            -->
     <!-- ================================================================= -->
@@ -391,7 +417,7 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
     '-noPositiveAcks' command-line argument or 'use positive acks = false'
     in the .ini configuration file.
     -->
-    <qos_profile name="ThroughputQos" base_name="BaseProfileQos">
+    <qos_profile name="ThroughputQos" base_name="TransportQos">
 
       <!-- === DataWriter Configuration: ================================= 
       
@@ -824,7 +850,7 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
     '-noPositiveAcks' command-line argument or 'use positive acks = false'
     INI file configuration.
     -->
-    <qos_profile name="LatencyQos" base_name="BaseProfileQos">
+    <qos_profile name="LatencyQos" base_name="TransportQos">
 
       <!-- === DataWriter Configuration: ================================= 
       
@@ -1154,5 +1180,6 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
         </durability>
       </datawriter_qos>
     </qos_profile>
+
   </qos_library>
 </dds>

--- a/perftest_qos_profiles.xml
+++ b/perftest_qos_profiles.xml
@@ -95,18 +95,11 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
         Three different transport plug-ins are built into the Connext core
         libraries (for most supported target platforms): UDPv4, shared memory, and
         UDPv6.
-
-        Important: transport_builtin.mask is configured automatically within the 
-        source code. Also, it can be modified with the input commands "-enableTcp"
-        and "-enableSharedMemory".
-          
-        Value set in the source code:
-          
+        -->
         <transport_builtin>
           <mask>UDPv4</mask>
         </transport_builtin>
-        -->
-
+        
         <property>
           <value>
             <!-- 

--- a/perftest_qos_profiles.xml
+++ b/perftest_qos_profiles.xml
@@ -448,16 +448,13 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
         DataReader if there are previous data samples that have not been 
         received yet due to a communication error.
 
-        The default value of reliability.kind is RELIABLE_RELIABILITY_QOS. The
-        reliability.kind configured here is ignored. It is configured 
-        automatically within the source code. reliability.kind can be modified
+        The default value of reliability.kind is RELIABLE_RELIABILITY_QOS.
+         
+        The reliability.kind can be modified
         to BEST_EFFORT_RELIABILITY_QOS using the command-line option -bestEffort.
-        
-        <reliability>
-          <kind>RELIABLE_RELIABILITY_QOS</kind>
-        </reliability>  
         -->
         <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
           <max_blocking_time>
             <sec>DURATION_INFINITE_SEC</sec>
             <nanosec>DURATION_INFINITE_NSEC</nanosec>
@@ -724,15 +721,15 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
         DataReader if there are previous data samples that have not been 
         received yet due to a communication error.
         
-        The default value of reliability.kind is RELIABLE_RELIABILITY_QOS. The
-        reliability.kind configured here is ignored. It is configured 
-        automatically within the source code. reliability.kind can be modified
-        to BEST_EFFORT_RELIABILITY_QOS using the command-line option -bestEffort.
+        The default value of reliability.kind is RELIABLE_RELIABILITY_QOS. 
         
+        The reliability.kind can be modified
+        to BEST_EFFORT_RELIABILITY_QOS using the command-line option -bestEffort.
+        -->        
         <reliability>
           <kind>RELIABLE_RELIABILITY_QOS</kind>
         </reliability>
-        -->
+
 
         <!--
         DurabilityQos policy specifies whether or not Connext will store and 
@@ -879,16 +876,12 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
         DataReader if there are previous data samples that have not been 
         received yet due to a communication error.
 
-        Important: Reliability.kind is not configured in this QoS file, so 
-        the value set here is ignored. The default value is 
-        RELIABLE_RELIABILITY_QOS. It can be modified to BEST_EFFORT_RELIABILITY_QOS
+        The default value is RELIABLE_RELIABILITY_QOS. 
+        It can be modified to BEST_EFFORT_RELIABILITY_QOS
         using the command-line option -bestEffort.
-        
-        <reliability>
-          <kind>RELIABLE_RELIABILITY_QOS</kind>
-        </reliability>
         -->
         <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
           <max_blocking_time>
             <sec>DURATION_INFINITE_SEC</sec>
             <nanosec>DURATION_INFINITE_NSEC</nanosec>
@@ -979,6 +972,22 @@ _KeepDurationUsec variable name corresponds to the command-line option -keepDura
       parameter not listed here will pick up the documented default value.
       -->
       <datareader_qos>
+      
+        <!--
+        Setting reliability.kind = RELIABLE_RELIABILITY_QOS, data samples 
+        originating from a single DataWriter cannot be made available to the
+        DataReader if there are previous data samples that have not been 
+        received yet due to a communication error.
+        
+        The default value of reliability.kind is RELIABLE_RELIABILITY_QOS. 
+        
+        The reliability.kind can be modified
+        to BEST_EFFORT_RELIABILITY_QOS using the command-line option -bestEffort.
+        -->        
+        <reliability>
+          <kind>RELIABLE_RELIABILITY_QOS</kind>
+        </reliability>
+      
         <!--
         DurabilityQos policy specifies whether or not Connext will store and 
         deliver previously published data samples to new DDSDataReader entities 

--- a/resource/routing_service/routingservice_cfg.xml
+++ b/resource/routing_service/routingservice_cfg.xml
@@ -119,8 +119,11 @@
             </datareader_qos>
 
         </qos_profile>
-
-        <qos_profile name="ThroughputQos" base_name="BaseProfileQos">
+        
+	    <qos_profile name="TransportQos" base_name="BaseProfileQos">
+	    </qos_profile>
+    
+        <qos_profile name="ThroughputQos" base_name="TransportQos">
 
             <datawriter_qos>
 
@@ -250,7 +253,7 @@
 
         </qos_profile>
 
-        <qos_profile name="LatencyQos" base_name="BaseProfileQos">
+        <qos_profile name="LatencyQos" base_name="TransportQos">
 
             <datawriter_qos>
 
@@ -389,17 +392,17 @@
         <domain_route name="DR">
             <participant_1>
                 <domain_id>0</domain_id>
-                <participant_qos base_name="PerformanceLibraries_Modified::BaseProfileQos"/>
+                <participant_qos base_name="PerformanceLibraries_Modified::TransportQos"/>
             </participant_1>
             <participant_2>
                 <domain_id>1</domain_id>
-                <participant_qos base_name="PerformanceLibraries_Modified::BaseProfileQos"/>
+                <participant_qos base_name="PerformanceLibraries_Modified::TransportQos"/>
             </participant_2>
 
             <session name="Perftest_routing">
 
-                <publisher_qos base_name="PerformanceLibraries_Modified::BaseProfileQos"/>
-                <subscriber_qos base_name="PerformanceLibraries_Modified::BaseProfileQos"/>
+                <publisher_qos base_name="PerformanceLibraries_Modified::TransportQos"/>
+                <subscriber_qos base_name="PerformanceLibraries_Modified::TransportQos"/>
 
                 <thread>
                     <priority>THREAD_PRIORITY_HIGH</priority>

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -1958,7 +1958,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
     }
 
     // Configure DDSDomainParticipant QOS
-    _factory->get_participant_qos_from_profile(qos, "PerftestQosLibrary", "BaseProfileQos");
+    _factory->get_participant_qos_from_profile(qos, "PerftestQosLibrary", "TransportQos");
 
   #ifdef RTI_SECURE_PERFTEST
     if (_secureUseSecure) {
@@ -2065,7 +2065,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
 
     // Create the DDSPublisher and DDSSubscriber
     _publisher = _participant->create_publisher_with_profile(
-        "PerftestQosLibrary", "BaseProfileQos", NULL, DDS_STATUS_MASK_NONE);
+        "PerftestQosLibrary", "TransportQos", NULL, DDS_STATUS_MASK_NONE);
     if (_publisher == NULL)
     {
         fprintf(stderr,"Problem creating publisher.\n");
@@ -2073,7 +2073,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
     }
 
     _subscriber = _participant->create_subscriber_with_profile(
-        "PerftestQosLibrary", "BaseProfileQos", NULL, DDS_STATUS_MASK_NONE);
+        "PerftestQosLibrary", "TransportQos", NULL, DDS_STATUS_MASK_NONE);
     if (_subscriber == NULL)
     {
         fprintf(stderr,"Problem creating subscriber.\n");

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -1989,7 +1989,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
     }
 
     // set transports to use
-    qos.transport_builtin.mask = DDS_TRANSPORTBUILTIN_UDPv4;
+    // default: use the transport specified by the the qos profile
     if (_UseTcpOnly) {
         qos.transport_builtin.mask = DDS_TRANSPORTBUILTIN_MASK_NONE;
         DDSPropertyQosPolicyHelper::add_property(

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -1958,7 +1958,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
     }
 
     // Configure DDSDomainParticipant QOS
-    _factory->get_participant_qos_from_profile(qos, "PerftestQosLibrary", "TransportQos");
+    _factory->get_participant_qos_from_profile(qos, _ProfileLibraryName, "TransportQos");
 
   #ifdef RTI_SECURE_PERFTEST
     if (_secureUseSecure) {
@@ -2065,7 +2065,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
 
     // Create the DDSPublisher and DDSSubscriber
     _publisher = _participant->create_publisher_with_profile(
-        "PerftestQosLibrary", "TransportQos", NULL, DDS_STATUS_MASK_NONE);
+    		_ProfileLibraryName, "TransportQos", NULL, DDS_STATUS_MASK_NONE);
     if (_publisher == NULL)
     {
         fprintf(stderr,"Problem creating publisher.\n");
@@ -2073,7 +2073,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
     }
 
     _subscriber = _participant->create_subscriber_with_profile(
-        "PerftestQosLibrary", "TransportQos", NULL, DDS_STATUS_MASK_NONE);
+    		_ProfileLibraryName, "TransportQos", NULL, DDS_STATUS_MASK_NONE);
     if (_subscriber == NULL)
     {
         fprintf(stderr,"Problem creating subscriber.\n");

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -2170,9 +2170,11 @@ IMessagingWriter *RTIDDSImpl<T>::CreateWriter(const char *topic_name)
     // only force reliability on throughput/latency topics
     if (strcmp(topic_name, perftest_cpp::_AnnouncementTopicName) != 0) {
         if (_IsReliable) {
-            dw_qos.reliability.kind = DDS_RELIABLE_RELIABILITY_QOS;
+        	// default: use the setting specified in the qos profile
+            //dw_qos.reliability.kind = DDS_RELIABLE_RELIABILITY_QOS;
         }
         else {
+        	// override to best-effort
             dw_qos.reliability.kind = DDS_BEST_EFFORT_RELIABILITY_QOS;
         }
     }

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -109,9 +109,11 @@ void RTIDDSImpl<T>::PrintCmdLineHelp()
             "\t                          queue, default 50\n" +
             "\t-domain <ID>            - RTI DDS Domain, default 1\n" +
             "\t-qosprofile <filename>  - Name of XML file for DDS Qos profiles, \n" +
-            "\t                          default perftest_qos_profiles.xml\n" +
+            "\t                          default: perftest_qos_profiles.xml\n" +
+            "\t-qosLibrary <lib name>  - Name of QoS Library for DDS Qos profiles, \n" +
+            "\t                          default: PerftestQosLibrary\n" +
             "\t-nic <ipaddr>           - Use only the nic specified by <ipaddr>.\n" +
-            "\t                          If unspecificed, use all available interfaces\n" +
+            "\t                          If unspecified, use all available interfaces\n" +
             "\t-multicast              - Use multicast to send data, default not to\n" +
             "\t                          use multicast\n" +
             "\t-nomulticast            - Do not use multicast to send data (default)\n" +
@@ -316,6 +318,13 @@ bool RTIDDSImpl<T>::ParseConfig(int argc, char *argv[])
                 return false;
             }
             _ProfileFile = argv[i];
+        } else if (IS_OPTION(argv[i], "-qosLibrary")) {
+            if ((i == (argc-1)) || *argv[++i] == '-')
+            {
+                fprintf(stderr, "Missing <library name> after -qosLibrary\n");
+                return false;
+            }
+            _ProfileLibraryName = argv[i];
         } else if (IS_OPTION(argv[i], "-multicast")) {
             _IsMulticast = true;
         } else if (IS_OPTION(argv[i], "-nomulticast")) {

--- a/srcCpp03/RTIDDSImpl.cxx
+++ b/srcCpp03/RTIDDSImpl.cxx
@@ -1504,7 +1504,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
 
     // setup the QOS profile file to be loaded
     dds::core::QosProvider qos_provider =
-        getQosProviderForProfile("PerftestQosLibrary","TransportQos");
+        getQosProviderForProfile( _ProfileLibraryName,"TransportQos");
     dds::domain::qos::DomainParticipantQos qos = qos_provider.participant_qos();
 
     std::map<std::string, std::string> properties =

--- a/srcCpp03/RTIDDSImpl.cxx
+++ b/srcCpp03/RTIDDSImpl.cxx
@@ -1675,8 +1675,10 @@ IMessagingWriter *RTIDDSImpl<T>::CreateWriter(const std::string &topic_name)
     // only force reliability on throughput/latency topics
     if (topic_name != perftest_cpp::_AnnouncementTopicName) {
         if (_IsReliable) {
-            qos_reliability = Reliability::Reliable(dds::core::Duration::infinite());
+        	// default: use the setting specified in the qos profile
+            //qos_reliability = Reliability::Reliable(dds::core::Duration::infinite());
         } else {
+        	// override to best-effort
             qos_reliability = Reliability::BestEffort();
         }
     }

--- a/srcCpp03/RTIDDSImpl.cxx
+++ b/srcCpp03/RTIDDSImpl.cxx
@@ -1504,7 +1504,7 @@ bool RTIDDSImpl<T>::Initialize(int argc, char *argv[])
 
     // setup the QOS profile file to be loaded
     dds::core::QosProvider qos_provider =
-        getQosProviderForProfile("PerftestQosLibrary","BaseProfileQos");
+        getQosProviderForProfile("PerftestQosLibrary","TransportQos");
     dds::domain::qos::DomainParticipantQos qos = qos_provider.participant_qos();
 
     std::map<std::string, std::string> properties =

--- a/srcCpp03/RTIDDSImpl.cxx
+++ b/srcCpp03/RTIDDSImpl.cxx
@@ -131,9 +131,11 @@ void RTIDDSImpl<T>::PrintCmdLineHelp() {
             "\t                          queue, default 50\n"
             "\t-domain <ID>            - RTI DDS Domain, default 1\n"
             "\t-qosprofile <filename>  - Name of XML file for DDS Qos profiles, \n"
-            "\t                          default perftest_qos_profiles.xml\n"
+            "\t                          default: perftest_qos_profiles.xml\n"
+            "\t-qosLibrary <lib name>  - Name of QoS Library for DDS Qos profiles, \n"
+            "\t                          default: PerftestQosLibrary\n"
             "\t-nic <ipaddr>           - Use only the nic specified by <ipaddr>.\n"
-            "\t                          If unspecificed, use all available interfaces\n"
+            "\t                          If unspecified, use all available interfaces\n"
             "\t-multicast              - Use multicast to send data, default not to\n"
             "\t                          use multicast\n"
             "\t-nomulticast            - Do not use multicast to send data (default)\n"
@@ -349,6 +351,13 @@ bool RTIDDSImpl<T>::ParseConfig(int argc, char *argv[])
                 throw std::logic_error("[Error] Error parsing commands");
             }
             _ProfileFile = argv[i];
+        } else if (IS_OPTION(argv[i], "-qosLibrary")) {
+            if ((i == (argc - 1)) || *argv[++i] == '-') {
+                std::cerr << "[Error] Missing <library name> after -qosLibrary"
+                        << std::endl;
+                throw std::logic_error("[Error] Error parsing commands");
+            }
+            _ProfileLibraryName = argv[i];
         } else if (IS_OPTION(argv[i], "-multicast")) {
             _IsMulticast = true;
         } else if (IS_OPTION(argv[i], "-nomulticast")) {

--- a/srcCs/RTIDDSImpl.cs
+++ b/srcCs/RTIDDSImpl.cs
@@ -1752,10 +1752,11 @@ namespace PerformanceTest
             {
                 if (_IsReliable)
                 {
+                    // default: use the setting specified in the qos profile
                     dw_qos.reliability.kind = DDS.ReliabilityQosPolicyKind.RELIABLE_RELIABILITY_QOS;
                 }
                 else
-                {
+                {	// override to best-effort
                     dw_qos.reliability.kind = DDS.ReliabilityQosPolicyKind.BEST_EFFORT_RELIABILITY_QOS;
                 }
             }

--- a/srcCs/RTIDDSImpl.cs
+++ b/srcCs/RTIDDSImpl.cs
@@ -64,7 +64,9 @@ namespace PerformanceTest
             "\t                          queue, default 50\n" +
             "\t-domain <ID>            - RTI DDS Domain, default 1\n      " +
             "\t-qosprofile <filename>  - Name of XML file for DDS Qos profiles,\n" +
-            "\t                          default perftest_qos_profiles.xml\n" +
+            "\t                          default: perftest_qos_profiles.xml\n" +
+            "\t-qosLibrary <lib name>  - Name of QoS Library for DDS Qos profiles, \n" +
+            "\t                          default: PerftestQosLibrary\n" +
             "\t-nic <ipaddr>           - Use only the nic specified by <ipaddr>,\n" +
             "\t                          If unspecificed, use all available interfaces\n" +
             "\t-multicast              - Use multicast to send data, default not to\n" +
@@ -291,6 +293,15 @@ namespace PerformanceTest
                         return false;
                     }
                     _ProfileFile = argv[i];
+                }
+                else if ("-qosLibrary".StartsWith(argv[i], true, null))
+                {
+                    if ((i == (argc - 1)) || argv[++i].StartsWith("-"))
+                    {
+                        Console.Error.Write("Missing library name after -qosLibrary\n");
+                        return false;
+                    }
+                    _ProfileLibraryName = argv[i];
                 }
                 else if ("-multicast".StartsWith(argv[i], true, null))
                 {

--- a/srcCs/RTIDDSImpl.cs
+++ b/srcCs/RTIDDSImpl.cs
@@ -1269,7 +1269,7 @@ namespace PerformanceTest
             }
 
             // Configure DDSDomainParticipant QOS
-            _factory.get_participant_qos_from_profile(qos, "PerftestQosLibrary", "BaseProfileQos");
+            _factory.get_participant_qos_from_profile(qos, "PerftestQosLibrary", "TransportQos");
 
             if (_secureUseSecure) {
                 // validate arguments
@@ -1387,7 +1387,7 @@ namespace PerformanceTest
             {
 
                 _publisher = _participant.create_publisher_with_profile(
-                    "PerftestQosLibrary", "BaseProfileQos", null, DDS.StatusMask.STATUS_MASK_NONE);
+                    "PerftestQosLibrary", "TransportQos", null, DDS.StatusMask.STATUS_MASK_NONE);
 
                 if (_publisher == null)
                 {
@@ -1396,7 +1396,7 @@ namespace PerformanceTest
                 }
 
                 _subscriber = _participant.create_subscriber_with_profile(
-                    "PerftestQosLibrary", "BaseProfileQos", null, DDS.StatusMask.STATUS_MASK_NONE);
+                    "PerftestQosLibrary", "TransportQos", null, DDS.StatusMask.STATUS_MASK_NONE);
 
                 if (_subscriber == null)
                 {

--- a/srcCs/RTIDDSImpl.cs
+++ b/srcCs/RTIDDSImpl.cs
@@ -1269,7 +1269,7 @@ namespace PerformanceTest
             }
 
             // Configure DDSDomainParticipant QOS
-            _factory.get_participant_qos_from_profile(qos, "PerftestQosLibrary", "TransportQos");
+            _factory.get_participant_qos_from_profile(qos, _ProfileLibraryName, "TransportQos");
 
             if (_secureUseSecure) {
                 // validate arguments
@@ -1387,7 +1387,7 @@ namespace PerformanceTest
             {
 
                 _publisher = _participant.create_publisher_with_profile(
-                    "PerftestQosLibrary", "TransportQos", null, DDS.StatusMask.STATUS_MASK_NONE);
+                    _ProfileLibraryName, "TransportQos", null, DDS.StatusMask.STATUS_MASK_NONE);
 
                 if (_publisher == null)
                 {
@@ -1396,7 +1396,7 @@ namespace PerformanceTest
                 }
 
                 _subscriber = _participant.create_subscriber_with_profile(
-                    "PerftestQosLibrary", "TransportQos", null, DDS.StatusMask.STATUS_MASK_NONE);
+                    _ProfileLibraryName, "TransportQos", null, DDS.StatusMask.STATUS_MASK_NONE);
 
                 if (_subscriber == null)
                 {

--- a/srcDoc/code_generation_and_compilation.rst
+++ b/srcDoc/code_generation_and_compilation.rst
@@ -333,7 +333,7 @@ examples:
 
    ::
 
-       ./build.sh --platform x64Win64VS2012 --dynamic --debug
+       ./build.bat --platform x64Win64VS2012 --dynamic --debug
 
 -  Generation and compilation for a given architecture
    (``x64Win64VS2012``) for all supported languages, enabling the
@@ -341,7 +341,7 @@ examples:
 
    ::
 
-       ./build.sh --platform x64Win64VS2012 --secure --openssl-home <PATH>
+       ./build.bat --platform x64Win64VS2012 --secure --openssl-home <PATH>
 
 -  Generation and compilation for a given architecture
    (``x64Win64VS2012``) for all supported languages, enabling the
@@ -351,7 +351,7 @@ examples:
 
    ::
 
-       ./build.sh --platform x64Win64VS2012 --secure --dynamic
+       ./build.bat --platform x64Win64VS2012 --secure --dynamic
 
 -  *RTI Perftest* directory clean-up.
 

--- a/srcDoc/large_samples.rst
+++ b/srcDoc/large_samples.rst
@@ -95,7 +95,7 @@ requirements.
 
 .. code:: xml
 
-    <qos_profile name="BaseProfileQos">
+    <qos_profile name="TransportQos">
         <participant_qos>
             . . .
             <property>

--- a/srcDoc/test_parameters.rst
+++ b/srcDoc/test_parameters.rst
@@ -247,10 +247,16 @@ Test Parameters for Publishing and Subscribing Applications
    **Default:** ``perftest_qos_profiles.xml``
 
    | The default file contains these QoS profiles:
-   | The ``ThroughputQos``, ``LatencyQos``, and ``AnnouncementQos``
-     profiles are used by default.
+   
+   |  The ``ThroughputQos``, ``LatencyQos``, and ``AnnouncementQos``
+   |   profiles are used by default (the DDS DataWriter/DataReader entities).
+   |
    | The ``NoAckThroughputQos`` and ``NoAckLatencyQos`` profiles are
-     used if you specify ``-noPositiveAcks``.
+   |  used if you specify ``-noPositiveAcks`` (the DDS 
+   |  DataWriter/DataReader entities).
+   |
+   | The ``TransportQos`` profile is used to configure the transports (the 
+   | DDS DomainParticipant/Publisher/Subscriber entities) 
 
    **Note:** some QoS values are ‘hard-coded’ in the application,
    therefore setting them in the XML file has no effect; see the See

--- a/srcDoc/test_parameters.rst
+++ b/srcDoc/test_parameters.rst
@@ -266,6 +266,12 @@ Test Parameters for Publishing and Subscribing Applications
    **Configuring QoS with XML, Chapter 17** in the *RTI Connext DDS Core
    Libraries* User’s Manual.
 
+- ``qosLibrary`` <library name>``
+
+    Name of QoS Library for DDS Qos profiles
+  
+  	**Default:** ``PerftestQosLibrary``
+
 -  ``-noXmlQos``
 
    Avoid loading the QoS from the xml profile, instead, they will be

--- a/srcDoc/test_parameters.rst
+++ b/srcDoc/test_parameters.rst
@@ -379,8 +379,11 @@ Test Parameters Only for Publishing Applications
 
    Allows you to limit the test duration by specifying the number of
    seconds to run the test.
+   
+   The first condition triggered will finish the test: ``-numIter`` or
+   execution time.
 
-   **Default:** feature is not set.
+   **Default:** 0 (i.e. don't set execution time)
 
 -  ``-heartbeatPeriod <sec>:<nanosec>``
 
@@ -424,8 +427,8 @@ Test Parameters Only for Publishing Applications
    See Number of Iterations vs. Latency Count.
 
    **Default:** ``-1`` (if ``-latencyTest`` is not specified,
-   automatically adjust to 10000; if -latency Test is specified,
-   automatically adjust to 1).
+   automatically adjust to 10000 or ``-numIter`` whichever is less; 
+   if -latency Test is specified, automatically adjust to 1).
 
    **Range:** must be ``<= -numIter``
 
@@ -449,7 +452,10 @@ Test Parameters Only for Publishing Applications
    If you set ``scan`` = ``true``, you cannot set this option (See
    ``-scan``).
 
-   | **Default:** ``0`` (infinite)
+   | **Default:** ``100000000`` for throughput tests or ``10000000``
+	               for latency tests (when ``-latencyTest`` is specified);
+	               also, see ``-executionTime``
+   
    | **Range:** ``latencyCount`` (adjusted value) or higher (see
      ``-latencyCount <count>``).
 

--- a/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
+++ b/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
@@ -324,7 +324,7 @@ public final class RTIDDSImpl<T> implements IMessaging {
 
         // Configure DDSDomainParticipant QOS
         DomainParticipantQos qos = new DomainParticipantQos();
-        _factory.get_participant_qos_from_profile(qos, "PerftestQosLibrary" , "BaseProfileQos");
+        _factory.get_participant_qos_from_profile(qos, "PerftestQosLibrary" , "TransportQos");
 
         if (_secureUseSecure) {
             // validate arguments
@@ -422,7 +422,7 @@ public final class RTIDDSImpl<T> implements IMessaging {
         // Create the Publisher and Subscriber
         {
             _publisher = _participant.create_publisher_with_profile(
-                "PerftestQosLibrary", "BaseProfileQos", null, StatusKind.STATUS_MASK_NONE);
+                "PerftestQosLibrary", "TransportQos", null, StatusKind.STATUS_MASK_NONE);
 
             if (_publisher == null) {
                 System.err.print("Problem creating publisher.\n");
@@ -430,7 +430,7 @@ public final class RTIDDSImpl<T> implements IMessaging {
             }
 
             _subscriber = _participant.create_subscriber_with_profile(
-                "PerftestQosLibrary", "BaseProfileQos", null, StatusKind.STATUS_MASK_NONE);
+                "PerftestQosLibrary", "TransportQos", null, StatusKind.STATUS_MASK_NONE);
 
             if (_subscriber == null) {
                 System.err.print("Problem creating subscriber.\n");

--- a/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
+++ b/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
@@ -324,7 +324,7 @@ public final class RTIDDSImpl<T> implements IMessaging {
 
         // Configure DDSDomainParticipant QOS
         DomainParticipantQos qos = new DomainParticipantQos();
-        _factory.get_participant_qos_from_profile(qos, "PerftestQosLibrary" , "TransportQos");
+        _factory.get_participant_qos_from_profile(qos, PROFILE_LIBRARY_NAME, "TransportQos");
 
         if (_secureUseSecure) {
             // validate arguments
@@ -422,7 +422,7 @@ public final class RTIDDSImpl<T> implements IMessaging {
         // Create the Publisher and Subscriber
         {
             _publisher = _participant.create_publisher_with_profile(
-                "PerftestQosLibrary", "TransportQos", null, StatusKind.STATUS_MASK_NONE);
+            	PROFILE_LIBRARY_NAME, "TransportQos", null, StatusKind.STATUS_MASK_NONE);
 
             if (_publisher == null) {
                 System.err.print("Problem creating publisher.\n");
@@ -430,7 +430,7 @@ public final class RTIDDSImpl<T> implements IMessaging {
             }
 
             _subscriber = _participant.create_subscriber_with_profile(
-                "PerftestQosLibrary", "TransportQos", null, StatusKind.STATUS_MASK_NONE);
+            	PROFILE_LIBRARY_NAME, "TransportQos", null, StatusKind.STATUS_MASK_NONE);
 
             if (_subscriber == null) {
                 System.err.print("Problem creating subscriber.\n");

--- a/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
+++ b/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
@@ -193,8 +193,10 @@ public final class RTIDDSImpl<T> implements IMessaging {
             "\t-sendQueueSize <number> - Sets number of samples (or batches) in send\n" +
             "\t                          queue, default 50\n" +
             "\t-domain <ID>            - RTI DDS Domain, default 1\n" +
-            "\t-qosprofile <filename>  - Name of XML file for DDS Qos profiles, default\n" +
-            "\t                          perftest_qos_profiles.xml\n" +
+            "\t-qosprofile <filename>  - Name of XML file for DDS Qos profiles,\n" +
+            "\t                          defaukt: perftest_qos_profiles.xml\n" +
+            "\t-qosLibrary <lib name>  - Name of QoS Library for DDS Qos profiles, \n" +
+            "\t                          default: PerftestQosLibrary\n" +
             "\t-nic <ipaddr>           - Use only the nic specified by <ipaddr>.\n" +
             "\t                          If unspecified, use all available interfaces\n" +
             "\t-multicast              - Use multicast to send data, default not to\n"+
@@ -1235,6 +1237,12 @@ public final class RTIDDSImpl<T> implements IMessaging {
                     return false;
                 }
                 _profileFile = argv[i];
+            } else if ("-qosLibrary".toLowerCase().startsWith(argv[i].toLowerCase())) {
+                if ((i == (argc - 1)) || argv[++i].startsWith("-")) {
+                    System.err.print("Missing <library name> after -qosLibrary\n");
+                    return false;
+                }
+                PROFILE_LIBRARY_NAME = argv[i];
             } else if ("-nomulticast".toLowerCase().startsWith(argv[i].toLowerCase())) {
                 _isMulticast = false;
             } else if ("-multicast".toLowerCase().startsWith(argv[i].toLowerCase())) {

--- a/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
+++ b/srcJava/com/rti/perftest/ddsimpl/RTIDDSImpl.java
@@ -901,9 +901,11 @@ public final class RTIDDSImpl<T> implements IMessaging {
         // Configure reliability
         if (!PerfTest.ANNOUNCEMENT_TOPIC_NAME.equals(topicName)) {
             if (_isReliable) {
-                dwQos.reliability.kind = ReliabilityQosPolicyKind.RELIABLE_RELIABILITY_QOS;
+            	// default: use the setting specified in the qos profile
+                //dwQos.reliability.kind = ReliabilityQosPolicyKind.RELIABLE_RELIABILITY_QOS;
  
             } else {
+            	// override to best-effort
                 dwQos.reliability.kind =
                     ReliabilityQosPolicyKind.BEST_EFFORT_RELIABILITY_QOS;
             }


### PR DESCRIPTION
Hi Javi:

I have made some enhancements to support the ability to more easily plugin a new Qos profiles without duplication of XML files, fixed some documentation errors, and also removed some hard-coded dependencies.

1. New feature: -qosLibrary <library name>

- Allows users to plugin custom qos profiles
- Custom profiles can extend the perftest builtin profile (without having to duplicate into a new copy)
- Custom profile can be an application specific profile, eg custom transports etc.
- Can easily compare application specific profile performance vs. optimized perftest qos profile
- Created example file to show how this is to be used

2. Added a new "TransportQos" profile to make it easy to plugin custom transport configurations.

3. Fixed some hard-coded assumptions:

- Now if a transport is not specified, the default as specified in the XML QoS profile is used. Previously, it was assumed to be UDPv4. Future: Should probably add a -enableUdp command line parameter to override the default in XML.

- Now if -bestEffort is not specified, the default setting for RELIABILITY comes from the XML profile.
Future: Should probably add a -reliable command line parameter to override the default in XML.

- Removed some internal hard-coded magic strings with variables that can be overridden via command line arguments

4. Fixed several documentation errors, inconsistencies, and clarified certain items.

More details can be found in the git log.

---

To Do:

- Renerate the qos_string.h from the updated perftest_qos_profiles.xml
 
Thanks
Rajive
