### PR TITLE
Fix incorrect parsing of the `-executionTime` command-line parameter

### DIFF
--- a/srcCpp/perftest_publisher.cxx
+++ b/srcCpp/perftest_publisher.cxx
@@ -726,6 +726,12 @@ bool perftest_cpp::ParseConfig(int argc, char *argv[])
             }
             _executionTime = (unsigned int) strtol(argv[i], NULL, 10);
 
+            if (_executionTime <= 0) {
+                fprintf(stderr,
+                        "-executionTime value must be a positive number greater than 0\n");
+                return false;
+            }
+
         } else if (IS_OPTION(argv[i], "-cpu"))
         {
             _showCpu = true;

--- a/srcCpp03/perftest_publisher.cxx
+++ b/srcCpp03/perftest_publisher.cxx
@@ -722,13 +722,20 @@ bool perftest_cpp::ParseConfig(int argc, char *argv[])
         }
         else if (IS_OPTION(argv[i], "-executionTime"))
         {
-            if ((i == (argc-1)) || *argv[++i] == '-')
-            {
+            if ((i == (argc-1)) || *argv[++i] == '-') {
                 std::cerr << "[Error] Missing <seconds> after -executionTime" << std::endl;
                 throw std::logic_error("[Error] Error parsing commands");
 
             }
+
             _executionTime = (unsigned int) strtol(argv[i], NULL, 10);
+
+            if (_executionTime <= 0) {
+                std::cerr << "[Error] -executionTime value must be a positive number "
+                          << "greater than 0"
+                          << std::endl;
+                return false;
+            }
 
         } else if (IS_OPTION(argv[i], "-cpu"))
         {

--- a/srcCs/perftest_publisher.cs
+++ b/srcCs/perftest_publisher.cs
@@ -1201,7 +1201,8 @@ namespace PerformanceTest {
 
                     if (!UInt64.TryParse(argv[i], out _executionTime))
                     {
-                        Console.Error.Write("Bad number for -executionTime\n");
+                        Console.Error.Write(
+                                "-executionTime value must be a positive number greater than 0\n");
                         return false;
                     }
                 }

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -48,8 +48,24 @@ releases:
 Release Notes Master
 --------------------
 
-What's New in Master
-~~~~~~~~~~~~~~~~~~~~
+What's Fixed in Master
+~~~~~~~~~~~~~~~~~~~~~~
+
+Fix incorrect parsing of the `-executionTime` command-line parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In previous releases, for the Classic and Modern C++ API implementations,
+the `-executionTime <sec>` command-line parameter would ignore any Invalid
+value for the `<sec>` parameter without any notification to the user.
+
+This behavior has been fixed and unified for all the API implementations,
+showing now an error when finding a wrong value for the `<sec>` option.
+
+Release Notes 2.4
+-----------------
+
+What's New in 2.4
+~~~~~~~~~~~~~~~~~
 
 Print a summary with the main setting of the test *RTI Perftest* will run (#46)(#67)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,8 +131,8 @@ Show percentage of packets lost in the subscriber side output (#81)
 number of packets lost. This number is displayed once per second with the rest of
 the statistics in the subscriber side, as well as at the end of the test.
 
-What's Fixed in Master
-~~~~~~~~~~~~~~~~~~~~~~
+What's Fixed in 2.4
+~~~~~~~~~~~~~~~~~~~
 
 Improve Dynamic Data Send() and Receive() operations (#55)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -51,8 +51,8 @@ Release Notes Master
 What's Fixed in Master
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Fix incorrect parsing of the `-executionTime` command-line parameter
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Fix incorrect parsing of the `-executionTime` command-line parameter (#102)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In previous releases, for the Classic and Modern C++ API implementations,
 the `-executionTime <sec>` command-line parameter would ignore any Invalid

--- a/srcJava/com/rti/perftest/harness/PerfTest.java
+++ b/srcJava/com/rti/perftest/harness/PerfTest.java
@@ -666,7 +666,8 @@ public final class PerfTest {
                 try {
                     _executionTime = (long)Integer.parseInt(argv[i]);
                 } catch (NumberFormatException nfx) {
-                    System.err.print("Bad executionTime\n");
+                    System.err.print(
+                            "-executionTime value must be a positive number greater than 0\n");
                     return false;
                 }
             }


### PR DESCRIPTION
This pull request is coming from the issue #102.