### PR TITLE
Removing Logic error on RTIDynamicDataSubscriber constructor.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -240,7 +240,7 @@ function build_cpp()
     ############################################################################
     # Generate files for srcCpp
 
-    rtiddsgen_command="\"${rtiddsgen_executable}\" -language ${classic_cpp_lang_string} -unboundedSupport -replace -create typefiles -create makefiles -platform ${platform} -additionalHeaderFiles \"RTIDDSLoggerDevice.h MessagingIF.h RTIDDSImpl.h perftest_cpp.h qos_string.h CpuMonitor.h PerftestTransport.h\" -additionalSourceFiles  \"RTIDDSLoggerDevice.cxx RTIDDSImpl.cxx CpuMonitor.cxx PerftestTransport.cxx\" -additionalDefines \"${additional_defines}\" ${rtiddsgen_extra_options} -d \"${classic_cpp_folder}\" \"${idl_location}/perftest.idl\" "
+    rtiddsgen_command="\"${rtiddsgen_executable}\" -language ${classic_cpp_lang_string} -unboundedSupport -replace -create typefiles -create makefiles -platform ${platform} -additionalHeaderFiles \"perftestReadersListeners.h RTIDDSLoggerDevice.h MessagingIF.h RTIDDSImpl.h perftest_cpp.h qos_string.h CpuMonitor.h PerftestTransport.h\" -additionalSourceFiles  \"perftestReadersListeners.cxx RTIDDSLoggerDevice.cxx RTIDDSImpl.cxx CpuMonitor.cxx PerftestTransport.cxx\" -additionalDefines \"${additional_defines}\" ${rtiddsgen_extra_options} -d \"${classic_cpp_folder}\" \"${idl_location}/perftest.idl\" "
 
     echo ""
     echo -e "${INFO_TAG} Generating types and makefiles for ${classic_cpp_lang_string}."

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -1167,9 +1167,11 @@ public:
     }
 
     void Shutdown() {
-        if (_writer->get_listener() != NULL) {
-            delete(_writer->get_listener());
-            _writer->set_listener(NULL);
+        if (_writer != NULL) {
+            if (_writer->get_listener() != NULL) {
+                delete(_writer->get_listener());
+                _writer->set_listener(NULL);
+            }
         }
 
         free(_instance_handles);
@@ -1606,12 +1608,14 @@ class RTISubscriber : public IMessagingReader
 
     void Shutdown()
     {
-        if (_reader->get_listener() != NULL) {
-            delete(_reader->get_listener());
-            _reader->set_listener(NULL);
+        if (_reader != NULL) {
+            if (_reader->get_listener() != NULL) {
+                delete(_reader->get_listener());
+                _reader->set_listener(NULL);
+            }
+            // loan may be outstanding during shutdown
+            _reader->return_loan(_data_seq, _info_seq);
         }
-        // loan may be outstanding during shutdown
-        _reader->return_loan(_data_seq, _info_seq);
     }
 
     TestMessage *ReceiveMessage()

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -111,7 +111,7 @@ void RTIDDSImpl<T>::Shutdown()
 
         DDSDomainParticipantListener* participant_listener = _participant->get_listener();
         if (participant_listener != NULL) {
-            delete(participant_listener);
+            delete participant_listener;
         }
 
         _participant->delete_contained_entities();
@@ -957,7 +957,7 @@ class RTIPublisher : public IMessagingWriter
     void Shutdown() {
         if (_writer != NULL) {
             if (_writer->get_listener() != NULL) {
-                delete(_writer->get_listener());
+                delete _writer->get_listener();
                 _writer->set_listener(NULL);
             }
         }
@@ -1176,7 +1176,7 @@ public:
     void Shutdown() {
         if (_writer != NULL) {
             if (_writer->get_listener() != NULL) {
-                delete(_writer->get_listener());
+                delete _writer->get_listener();
                 _writer->set_listener(NULL);
             }
         }
@@ -1619,7 +1619,7 @@ class RTISubscriber : public IMessagingReader
     {
         if (_reader != NULL) {
             if (_reader->get_listener() != NULL) {
-                delete(_reader->get_listener());
+                delete _reader->get_listener();
                 _reader->set_listener(NULL);
             }
             // loan may be outstanding during shutdown
@@ -1780,7 +1780,7 @@ class RTIDynamicDataSubscriber : public IMessagingReader
     {
         if (_reader != NULL) {
             if (_reader->get_listener() != NULL) {
-                delete (_reader->get_listener());
+                delete _reader->get_listener();
                 _reader->set_listener(NULL);
             }
             // loan may be outstanding during shutdown

--- a/srcCpp/RTIDDSImpl.h
+++ b/srcCpp/RTIDDSImpl.h
@@ -91,7 +91,6 @@ class RTIDDSImpl : public IMessaging
         _participant = NULL;
         _subscriber = NULL;
         _publisher = NULL;
-        _reader = NULL;
         _typename = T::TypeSupport::get_type_name();
 
         _pongSemaphore = NULL;
@@ -205,7 +204,6 @@ class RTIDDSImpl : public IMessaging
     DDSDomainParticipant        *_participant;
     DDSSubscriber               *_subscriber;
     DDSPublisher                *_publisher;
-    DDSDataReader               *_reader;
     const char                  *_typename;
 
     RTIOsapiSemaphore *_pongSemaphore;

--- a/srcCpp/RTIDDSImpl.h
+++ b/srcCpp/RTIDDSImpl.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <algorithm>
 #include <map>
+#include <stdexcept> 
 #include "MessagingIF.h"
 #include "perftestSupport.h"
 #include "PerftestTransport.h"

--- a/srcCpp/perftestReadersListeners.cxx
+++ b/srcCpp/perftestReadersListeners.cxx
@@ -1,0 +1,475 @@
+/*
+ * (c) 2005-2018  Copyright, Real-Time Innovations, Inc. All rights reserved.
+ * Subject to Eclipse Public License v1.0; see LICENSE.md for details.
+ */
+
+#include "perftestReadersListeners.h"
+
+
+/* ----------------------------------------------------------------*/
+/* ---------------------- ThroughputListener ----------------------*/
+
+ThroughputListener::ThroughputListener(
+        IMessagingWriter *writer,
+        IMessagingReader *reader,
+        bool UseCft,
+        int numPublishers)
+        : packetsReceived(0),
+          bytesReceived(0),
+          missingPackets(0),
+          lastDataLength(-1),
+          changeSize(false),
+          intervalDataLength(-1),
+          intervalPacketsReceived(0),
+          intervalBytesReceived(0),
+          intervalMissingPackets(0),
+          intervalTime(0),
+          beginTime(0),
+          missingPacketsPercent(0.0),
+          _reader(reader),
+          _writer(writer),
+          _numPublishers(numPublishers),
+          _useCft(UseCft)
+{
+    end_test = false;
+    _lastSeqNum = new unsigned long[numPublishers];
+    for (int i = 0; i < numPublishers; i++) {
+        _lastSeqNum[i] = 0;
+    }
+}
+
+ThroughputListener::~ThroughputListener()
+{
+    if (_lastSeqNum != NULL) {
+        delete[] _lastSeqNum;
+    }
+}
+
+IMessagingReader *ThroughputListener::get_reader()
+{
+    return _reader;
+}
+
+void ThroughputListener::ProcessMessage(TestMessage &message)
+{
+    if (message.entity_id >= _numPublishers || message.entity_id < 0) {
+        printf("ProcessMessage: message content no valid. "
+                "message.entity_id out of bounds\n");
+        return;
+    }
+    // Check for test initialization messages
+    if (message.size == perftest_cpp::INITIALIZE_SIZE) {
+        _writer->Send(message);
+        _writer->Flush();
+        return;
+    } else if (message.size == perftest_cpp::FINISHED_SIZE) {
+        /*
+         * PERFTEST-97
+         * We check the entity_id of the publisher to see if it has already
+         * send a FINISHED_SIZE message. If he has we ignore any new one.
+         * Else, we add it to a vector. Once that vector contains all the
+         * ids of the publishers the subscriber is suppose to know, that
+         * means that all the publishers have finished sending data samples,
+         * so it is time to finish the subscriber.
+         */
+        if (std::find(
+                    _finishedPublishers.begin(),
+                    _finishedPublishers.end(),
+                    message.entity_id)
+                != _finishedPublishers.end()) {
+            return;
+        }
+
+        if (end_test) {
+            return;
+        }
+
+        _finishedPublishers.push_back(message.entity_id);
+
+        if (_finishedPublishers.size() >= (unsigned int) _numPublishers) {
+            print_summary(message);
+            end_test = true;
+        }
+        return;
+    }
+
+    // Send back a packet if this is a ping
+    if ((message.latency_ping == perftest_cpp::_SubID)
+            || (_useCft && message.latency_ping != -1)) {
+        _writer->Send(message);
+        _writer->Flush();
+    }
+
+    // Always check if need to reset internals
+    if (message.size == perftest_cpp::LENGTH_CHANGED_SIZE) {
+        print_summary(message);
+        changeSize = true;
+        return;
+    }
+
+    // case where not running a scan
+    if (message.size != lastDataLength) {
+        packetsReceived = 0;
+        bytesReceived = 0;
+        missingPackets = 0;
+
+        for (int i = 0; i < _numPublishers; i++) {
+            _lastSeqNum[i] = 0;
+        }
+
+        beginTime = perftest_cpp::GetTimeUsec();
+
+        if (perftest_cpp::_PrintIntervals) {
+            printf("\n\n********** New data length is %d\n",
+                    message.size + perftest_cpp::OVERHEAD_BYTES);
+            fflush(stdout);
+        }
+    }
+
+    lastDataLength = message.size;
+    ++packetsReceived;
+    bytesReceived
+            += (unsigned long long) (message.size + perftest_cpp::OVERHEAD_BYTES);
+
+    if (!_useCft) {
+        // detect missing packets
+        if (_lastSeqNum[message.entity_id] == 0) {
+            _lastSeqNum[message.entity_id] = message.seq_num;
+        } else {
+            if (message.seq_num != ++_lastSeqNum[message.entity_id]) {
+                // only track if skipped, might have restarted pub
+                if (message.seq_num > _lastSeqNum[message.entity_id]) {
+                    missingPackets
+                            += message.seq_num - _lastSeqNum[message.entity_id];
+                }
+                _lastSeqNum[message.entity_id] = message.seq_num;
+            }
+        }
+    }
+}
+
+void ThroughputListener::print_summary(TestMessage &message)
+{
+    // store the info for this interval
+    unsigned long long now = perftest_cpp::GetTimeUsec();
+
+    if (intervalDataLength != lastDataLength) {
+        if (!_useCft) {
+            // detect missing packets
+            if (message.seq_num != _lastSeqNum[message.entity_id]) {
+                // only track if skipped, might have restarted pub
+                if (message.seq_num > _lastSeqNum[message.entity_id]) {
+                    missingPackets += message.seq_num
+                            - _lastSeqNum[message.entity_id];
+                }
+            }
+        }
+
+        intervalTime = now - beginTime;
+        intervalPacketsReceived = packetsReceived;
+        intervalBytesReceived = bytesReceived;
+        intervalMissingPackets = missingPackets;
+        intervalDataLength = lastDataLength;
+        missingPacketsPercent = 0;
+
+        // Calculations of missing package percent
+        if (intervalPacketsReceived + intervalMissingPackets != 0) {
+            missingPacketsPercent
+                    = (float) ((intervalMissingPackets * 100.0) / (float) (intervalPacketsReceived + intervalMissingPackets));
+        }
+
+        std::string outputCpu = "";
+        if (perftest_cpp::_showCpu) {
+            outputCpu = cpu.get_cpu_average();
+        }
+        printf("Length: %5d  Packets: %8llu  Packets/s(ave): %7llu  "
+                "Mbps(ave): %7.1lf  Lost: %5llu (%1.2f%%) %s\n",
+                intervalDataLength + perftest_cpp::OVERHEAD_BYTES,
+                intervalPacketsReceived,
+                intervalPacketsReceived * 1000000 / intervalTime,
+                intervalBytesReceived * 1000000.0 / intervalTime * 8.0
+                        / 1000.0 / 1000.0,
+                intervalMissingPackets,
+                missingPacketsPercent,
+                outputCpu.c_str());
+        fflush(stdout);
+    }
+
+    packetsReceived = 0;
+    bytesReceived = 0;
+    missingPackets = 0;
+    // length changed only used in scan mode in which case
+    // there is only 1 publisher with ID 0
+    _lastSeqNum[0] = 0;
+    beginTime = now;
+}
+
+
+/* ------------------------------------------------------------------*/
+/* ---------------------- AnnouncementListener ----------------------*/
+void AnnouncementListener::ProcessMessage(TestMessage &message)
+{
+    /*
+     * The subscriberList vector contains the list of discovered
+     * subscribers.
+     *
+     * - If the message.size is INITIALIZE or LENGTH_CHANGED and the
+     *   subscriber is not in the list, it will be added.
+     * - If the message.size is FINISHED_SIZE and the
+     *   subscriber is in the list, it will be removed.
+     *
+     * The publisher access to this list to verify:
+     * - If all the subscribers are discovered or notified about the length
+     *   being changed.
+     * - If all the subscribers are notified that the test has finished.
+     */
+    if ((message.size == perftest_cpp::INITIALIZE_SIZE
+            || message.size == perftest_cpp::LENGTH_CHANGED_SIZE)
+            && std::find(
+                    subscriberList.begin(),
+                    subscriberList.end(),
+                    message.entity_id)
+                    == subscriberList.end()) {
+        subscriberList.push_back(message.entity_id);
+    } else if (message.size == perftest_cpp::FINISHED_SIZE) {
+        std::vector<int>::iterator position = std::find(
+                subscriberList.begin(),
+                subscriberList.end(),
+                message.entity_id);
+        if (position != subscriberList.end()) {
+            subscriberList.erase(position);
+        }
+    }
+}
+
+
+/* -------------------------------------------------------------*/
+/* ---------------------- LatencyListener ----------------------*/
+LatencyListener::LatencyListener(
+        unsigned int numLatency,
+        IMessagingReader *reader,
+        IMessagingWriter *writer)
+        : _latencySum(0),
+          _latencySumSquare(0),
+          _count(0),
+          _latencyMin(perftest_cpp::LATENCY_RESET_VALUE),
+          _latencyMax(0),
+          _lastDataLength(0),
+          _clockSkewCount(0),
+          _writer(writer),
+          _reader(reader)
+{
+    if (numLatency > 0) {
+        _numLatency = numLatency;
+
+        /*
+         * PERFTEST-109
+         * _numLatency can be a big number, so this "new array" could
+         * easily return a bad_alloc exception (specially in embedded
+         * platforms with low memory settings). Therefore we catch the
+         * exception to log this specific problem and then rethrow it.
+         */
+        try {
+            _latencyHistory = new unsigned long[_numLatency];
+        } catch (const std::bad_alloc &) {
+            fprintf(stderr,
+                    "LatencyListener: Not able to allocate %ul "
+                    "elements in _latencyHistory array",
+                    _numLatency);
+            throw;
+        }
+
+    } else {
+        _latencyHistory = NULL;
+        _numLatency = 0;
+    }
+
+    end_test = false;
+}
+
+void LatencyListener::print_summary_latency()
+{
+    double latency_ave;
+    double latency_std;
+    std::string outputCpu = "";
+    if (_count == 0) {
+        return;
+    }
+
+    if (_clockSkewCount != 0) {
+        fprintf(stderr,
+                "The following latency result may not be accurate because "
+                "clock skew happens %lu times\n",
+                _clockSkewCount);
+        fflush(stderr);
+    }
+
+    // sort the array (in ascending order)
+    std::sort(_latencyHistory, _latencyHistory + _count);
+    latency_ave = (double) _latencySum / _count;
+    latency_std
+            = sqrt((double) _latencySumSquare / (double) _count
+                    - (latency_ave * latency_ave));
+
+    if (perftest_cpp::_showCpu) {
+        outputCpu = cpu.get_cpu_average();
+    }
+
+    printf("Length: %5d  Latency: Ave %6.0lf us  Std %6.1lf us  "
+            "Min %6lu us  Max %6lu us  50%% %6lu us  90%% %6lu us  99%% "
+            "%6lu us  99.99%% %6lu us  99.9999%% %6lu us %s\n",
+            _lastDataLength + perftest_cpp::OVERHEAD_BYTES,
+            latency_ave,
+            latency_std,
+            _latencyMin,
+            _latencyMax,
+            _latencyHistory[_count * 50 / 100],
+            _latencyHistory[_count * 90 / 100],
+            _latencyHistory[_count * 99 / 100],
+            _latencyHistory[(int) (_count * (9999.0 / 10000))],
+            _latencyHistory[(int) (_count * (999999.0 / 1000000))],
+            outputCpu.c_str());
+    fflush(stdout);
+
+    _latencySum = 0;
+    _latencySumSquare = 0;
+    _latencyMin = perftest_cpp::LATENCY_RESET_VALUE;
+    _latencyMax = 0;
+    _count = 0;
+    _clockSkewCount = 0;
+
+    return;
+}
+
+LatencyListener::~LatencyListener()
+{
+    if (_latencyHistory != NULL) {
+        delete[] _latencyHistory;
+    }
+}
+
+IMessagingReader *LatencyListener::get_reader()
+{
+    return _reader;
+}
+
+void LatencyListener::ProcessMessage(TestMessage &message)
+{
+    unsigned long long now, sentTime;
+    unsigned long latency;
+    int sec;
+    unsigned int usec;
+    double latency_ave;
+    double latency_std;
+    std::string outputCpu = "";
+
+    now = perftest_cpp::GetTimeUsec();
+
+    switch (message.size) {
+    // Initializing message, don't process
+    case perftest_cpp::INITIALIZE_SIZE:
+        return;
+
+    // Test finished message
+    case perftest_cpp::FINISHED_SIZE:
+        return;
+
+    // Data length is changing size
+    case perftest_cpp::LENGTH_CHANGED_SIZE:
+        print_summary_latency();
+        return;
+
+    default:
+        break;
+    }
+
+    if (_lastDataLength != message.size) {
+        _latencySum = 0;
+        _latencySumSquare = 0;
+        _latencyMin = perftest_cpp::LATENCY_RESET_VALUE;
+        _latencyMax = 0;
+        _count = 0;
+    }
+
+    sec = message.timestamp_sec;
+    usec = message.timestamp_usec;
+    sentTime = ((unsigned long long) sec << 32) | (unsigned long long) usec;
+
+    if (now >= sentTime) {
+        latency = (unsigned long) (now - sentTime);
+
+        // keep track of one-way latency
+        latency /= 2;
+    } else {
+        fprintf(stderr,
+                "Clock skew suspected: received time %llu usec, sent time "
+                "%llu usec",
+                now,
+                sentTime);
+        ++_clockSkewCount;
+        return;
+    }
+
+    // store value for percentile calculations
+    if (_latencyHistory != NULL) {
+        if (_count >= _numLatency) {
+            fprintf(stderr,
+                    "Too many latency pongs received.  Do you have more "
+                    "than 1 app with -pidMultiPubTest = 0 or "
+                    "-sidMultiSubTest 0?\n");
+            return;
+        } else {
+            _latencyHistory[_count] = latency;
+        }
+    }
+
+    if (_latencyMin == perftest_cpp::LATENCY_RESET_VALUE) {
+        _latencyMin = latency;
+        _latencyMax = latency;
+    } else {
+        if (latency < _latencyMin) {
+            _latencyMin = latency;
+        } else if (latency > _latencyMax) {
+            _latencyMax = latency;
+        }
+    }
+
+    ++_count;
+    _latencySum += latency;
+    _latencySumSquare
+            += ((unsigned long long) latency
+                * (unsigned long long) latency);
+
+    // if data sized changed, print out stats and zero counters
+    if (_lastDataLength != message.size) {
+        _lastDataLength = message.size;
+
+        if (perftest_cpp::_PrintIntervals) {
+            printf("\n\n********** New data length is %d\n",
+                    _lastDataLength + perftest_cpp::OVERHEAD_BYTES);
+        }
+    } else {
+        if (perftest_cpp::_PrintIntervals) {
+            latency_ave = (double) _latencySum / (double) _count;
+            latency_std
+                    = sqrt((double) _latencySumSquare / (double) _count
+                            - (latency_ave * latency_ave));
+
+            if (perftest_cpp::_showCpu) {
+                outputCpu = cpu.get_cpu_instant();
+            }
+            printf("One way Latency: %6lu us  Ave %6.0lf us  Std %6.1lf us "
+                    " Min %6lu us  Max %6lu %s\n",
+                    latency,
+                    latency_ave,
+                    latency_std,
+                    _latencyMin,
+                    _latencyMax,
+                    outputCpu.c_str());
+        }
+    }
+
+    if (_writer != NULL) {
+        _writer->notifyPingResponse();
+    }
+}

--- a/srcCpp/perftestReadersListeners.cxx
+++ b/srcCpp/perftestReadersListeners.cxx
@@ -174,8 +174,9 @@ void ThroughputListener::print_summary(TestMessage &message)
 
         // Calculations of missing package percent
         if (intervalPacketsReceived + intervalMissingPackets != 0) {
-            missingPacketsPercent
-                    = (float) ((intervalMissingPackets * 100.0) / (float) (intervalPacketsReceived + intervalMissingPackets));
+            missingPacketsPercent = (float) ((intervalMissingPackets * 100.0)
+                    / (float) (intervalPacketsReceived
+                    + intervalMissingPackets));
         }
 
         std::string outputCpu = "";

--- a/srcCpp/perftestReadersListeners.h
+++ b/srcCpp/perftestReadersListeners.h
@@ -8,7 +8,6 @@
 
 #include "MessagingIF.h"
 #include "CpuMonitor.h"
-#include "perftest_cpp.h"
 #include <iostream>
 #include <math.h>
 #include <stdio.h>
@@ -135,5 +134,13 @@ public:
     void ProcessMessage(TestMessage &message);
 };
 
+
+/*
+ * perftestReaderListener.cxx have some dependencies from perftest_cpp.h.
+ * Also perftest_cpp.h needs the tree classes defined here.
+ * As solution, the include of perftest_cpp.h has been moved to the
+ * end of this file.
+ */
+#include "perftest_cpp.h"
 
 #endif

--- a/srcCpp/perftestReadersListeners.h
+++ b/srcCpp/perftestReadersListeners.h
@@ -1,0 +1,141 @@
+/*
+ * (c) 2005-2018  Copyright, Real-Time Innovations, Inc. All rights reserved.
+ * Subject to Eclipse Public License v1.0; see LICENSE.md for details.
+ */
+
+#ifndef __PERFTEST_READER_LISTENER_H__
+#define __PERFTEST_READER_LISTENER_H__
+
+#include "MessagingIF.h"
+#include "CpuMonitor.h"
+#include "perftest_cpp.h"
+#include <iostream>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <vector>
+// STL needed for sorting
+#include <algorithm>
+#include <limits.h>
+
+#ifdef RTI_WIN32
+  #include <windows.h>
+#else
+  #ifndef RTI_VXWORKS
+    #include <sys/time.h>
+  #endif
+  #include <sched.h>
+  #include <fcntl.h>
+  #include <unistd.h>
+  #include <signal.h>
+#endif
+
+/*********************************************************
+ * Listener for the Subscriber side
+ *
+ * Keeps stats on data received per second.
+ * Returns a ping for latency packets
+ */
+class ThroughputListener : public IMessagingCB {
+    /*TODO: check which member should be private */
+    /*TODO: fix name convention */
+public:
+    unsigned long long packetsReceived;
+    unsigned long long bytesReceived;
+    unsigned long long missingPackets;
+    int lastDataLength;
+    bool changeSize;
+
+    // store info for the last data set
+    int intervalDataLength;
+    unsigned long long intervalPacketsReceived;
+    unsigned long long intervalBytesReceived;
+    unsigned long long intervalMissingPackets;
+    unsigned long long intervalTime, beginTime;
+    float missingPacketsPercent;
+    CpuMonitor cpu;
+
+private:
+    IMessagingReader *_reader;
+    IMessagingWriter *_writer;
+    unsigned long *_lastSeqNum;
+
+    int _numPublishers;
+    std::vector<int> _finishedPublishers;
+    bool _useCft;
+
+public:
+    ThroughputListener(
+            IMessagingWriter *writer,
+            IMessagingReader *reader = NULL,
+            bool UseCft = false,
+            int numPublishers = 1);
+
+    ~ThroughputListener();
+
+    IMessagingReader *get_reader();
+
+    void ProcessMessage(TestMessage &message);
+
+    void print_summary(TestMessage &message);
+
+
+};
+
+
+/*********************************************************
+ * Data listener for the Announcement
+ *
+ * Receives an announcement message from a Subscriber once
+ * the subscriber has discovered every Publisher.
+ */
+class AnnouncementListener : public IMessagingCB {
+public:
+    std::vector<int> subscriberList;
+
+    AnnouncementListener(){}
+
+    void ProcessMessage(TestMessage &message);
+};
+
+/*********************************************************
+ * Data listener for the Publisher side.
+ *
+ * Receives latency ping from Subscriber and does
+ * round trip latency calculations
+ */
+class LatencyListener : public IMessagingCB {
+private:
+    unsigned long long _latencySum;
+    unsigned long long _latencySumSquare;
+    unsigned long long _count;
+    unsigned long _latencyMin;
+    unsigned long _latencyMax;
+    int _lastDataLength;
+    unsigned long *_latencyHistory;
+    unsigned long _clockSkewCount;
+    unsigned int _numLatency;
+    IMessagingWriter *_writer;
+    IMessagingReader *_reader;
+
+public:
+    CpuMonitor cpu;
+
+public:
+    LatencyListener(
+            unsigned int numLatency,
+            IMessagingReader *reader,
+            IMessagingWriter *writer);
+
+    ~LatencyListener();
+
+    IMessagingReader *get_reader();
+
+    void print_summary_latency();
+
+    void ProcessMessage(TestMessage &message);
+};
+
+
+#endif

--- a/srcCpp/perftestReadersListeners.h
+++ b/srcCpp/perftestReadersListeners.h
@@ -38,8 +38,6 @@
  * Returns a ping for latency packets
  */
 class ThroughputListener : public IMessagingCB {
-    /*TODO: check which member should be private */
-    /*TODO: fix name convention */
 public:
     unsigned long long packetsReceived;
     unsigned long long bytesReceived;

--- a/srcCpp/perftest_cpp.h
+++ b/srcCpp/perftest_cpp.h
@@ -5,7 +5,6 @@
  * (c) 2005-2017  Copyright, Real-Time Innovations, Inc. All rights reserved.
  * Subject to Eclipse Public License v1.0; see LICENSE.md for details.
  */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -28,21 +27,14 @@
   #include <signal.h>
 #endif
 
-/*
- * This is needed by MilliSleep in VxWorks, since in some versions the usleep
- * function does not exist. In the rest of OS we won't make use of it.
- */
-#if defined(RTI_VXWORKS)
-  #include "ndds/ndds_cpp.h"
-#endif
-
 #include "MessagingIF.h"
+#include "ndds/ndds_cpp.h" /* Necessary for DDS_ProductVersion_t*/
 #include "clock/clock_highResolution.h"
 #include "osapi/osapi_ntptime.h"
 
 class ThroughputListener;
-class LatencyListener;
 class AnnouncementListener;
+class LatencyListener;
 
 struct Perftest_ProductVersion_t
 {
@@ -181,5 +173,7 @@ private:
   #endif
 
 };
+
+#include "perftestReadersListeners.h"
 
 #endif // __PERFTEST_CPP_H__

--- a/srcCpp/perftest_cpp.h
+++ b/srcCpp/perftest_cpp.h
@@ -32,6 +32,12 @@
 #include "clock/clock_highResolution.h"
 #include "osapi/osapi_ntptime.h"
 
+/*
+ * perftestReaderListener.h have some dependencies from this class. Also
+ * perftest_cpp.h needs some classes from perftestReadersListener.h So, add the
+ * include of perftestReaderListener.h at the end and define the tree needed
+ * classes here.
+ */
 class ThroughputListener;
 class AnnouncementListener;
 class LatencyListener;

--- a/srcCpp/perftest_cpp.h
+++ b/srcCpp/perftest_cpp.h
@@ -28,20 +28,10 @@
 #endif
 
 #include "MessagingIF.h"
+#include "perftestReadersListeners.h"
 #include "ndds/ndds_cpp.h" /* Necessary for DDS_ProductVersion_t*/
 #include "clock/clock_highResolution.h"
 #include "osapi/osapi_ntptime.h"
-
-/*
- * perftestReaderListener.h have some dependencies from this class.
- * Also perftest_cpp.h needs the tree following classes from
- * perftestReadersListener.h.
- * As solution, the include of perftestReaderListener.h has been moved to the
- * end of this file and the tree classes has been defined here.
- */
-class ThroughputListener;
-class AnnouncementListener;
-class LatencyListener;
 
 struct Perftest_ProductVersion_t
 {
@@ -180,7 +170,5 @@ private:
   #endif
 
 };
-
-#include "perftestReadersListeners.h"
 
 #endif // __PERFTEST_CPP_H__

--- a/srcCpp/perftest_cpp.h
+++ b/srcCpp/perftest_cpp.h
@@ -33,10 +33,11 @@
 #include "osapi/osapi_ntptime.h"
 
 /*
- * perftestReaderListener.h have some dependencies from this class. Also
- * perftest_cpp.h needs some classes from perftestReadersListener.h So, add the
- * include of perftestReaderListener.h at the end and define the tree needed
- * classes here.
+ * perftestReaderListener.h have some dependencies from this class.
+ * Also perftest_cpp.h needs the tree following classes from
+ * perftestReadersListener.h.
+ * As solution, the include of perftestReaderListener.h has been moved to the
+ * end of this file and the tree classes has been defined here.
  */
 class ThroughputListener;
 class AnnouncementListener;
@@ -116,14 +117,14 @@ class perftest_cpp
     bool _useCft;
     static const Perftest_ProductVersion_t _version;
 
-    /* Members for publisher and subscriber */
-    ThroughputListener *_throughput_reader_listener;
-    LatencyListener *_latency_reader_listener;
-    AnnouncementListener *_announcement_reader_listener;
+    /* Members used by publisher and subscriber functions */
+    ThroughputListener *_throughputReaderListener;
+    LatencyListener *_latencyReaderListener;
+    AnnouncementListener *_announcementReaderListener;
     IMessagingReader *_reader;
     IMessagingWriter *_writer;
-    IMessagingReader *_announcement_reader;
-    IMessagingWriter *_announcement_writer;
+    IMessagingReader *_announcementReader;
+    IMessagingWriter *_announcementWriter;
 
 private:
     static void SetTimeout(unsigned int executionTimeInSeconds, bool _isScan = false);

--- a/srcCpp/perftest_cpp.h
+++ b/srcCpp/perftest_cpp.h
@@ -40,6 +40,10 @@
 #include "clock/clock_highResolution.h"
 #include "osapi/osapi_ntptime.h"
 
+class ThroughputListener;
+class LatencyListener;
+class AnnouncementListener;
+
 struct Perftest_ProductVersion_t
 {
   char major;
@@ -114,7 +118,16 @@ class perftest_cpp
     bool _useCft;
     static const Perftest_ProductVersion_t _version;
 
-  private:
+    /* Members for publisher and subscriber */
+    ThroughputListener *_throughput_reader_listener;
+    LatencyListener *_latency_reader_listener;
+    AnnouncementListener *_announcement_reader_listener;
+    IMessagingReader *_reader;
+    IMessagingWriter *_writer;
+    IMessagingReader *_announcement_reader;
+    IMessagingWriter *_announcement_writer;
+
+private:
     static void SetTimeout(unsigned int executionTimeInSeconds, bool _isScan = false);
 
     /* The following three members are used in a static callback

--- a/srcCpp/perftest_publisher.cxx
+++ b/srcCpp/perftest_publisher.cxx
@@ -187,31 +187,31 @@ perftest_cpp::~perftest_cpp()
     }
 
     if (_throughputReaderListener != NULL) {
-        delete (_throughputReaderListener);
+        delete _throughputReaderListener;
     }
 
     if (_latencyReaderListener != NULL) {
-        delete (_latencyReaderListener);
+        delete _latencyReaderListener;
     }
 
     if (_announcementReaderListener != NULL) {
-        delete (_announcementReaderListener);
+        delete _announcementReaderListener;
     }
 
     if (_reader != NULL) {
-        delete (_reader);
+        delete _reader;
     }
 
     if (_writer != NULL) {
-        delete (_writer);
+        delete _writer;
     }
 
     if (_announcementReader != NULL) {
-        delete (_announcementReader);
+        delete _announcementReader;
     }
 
     if (_announcementWriter != NULL) {
-        delete (_announcementWriter);
+        delete _announcementWriter;
     }
 
     if (_MessagingImpl != NULL) {

--- a/srcCpp03/RTIDDSImpl.cxx
+++ b/srcCpp03/RTIDDSImpl.cxx
@@ -1302,7 +1302,7 @@ public:
     void Shutdown() {
         _reader.listener(NULL, dds::core::status::StatusMask::none());
         if (_readerListener != NULL) {
-            delete(_readerListener);
+            delete _readerListener;
         }
     }
 

--- a/srcCpp03/perftest_publisher.cxx
+++ b/srcCpp03/perftest_publisher.cxx
@@ -1374,20 +1374,20 @@ int perftest_cpp::RunSubscriber()
     perftest_cpp::MilliSleep(1000);
 
     if (announcement_writer != NULL) {
-        delete(announcement_writer);
+        delete announcement_writer;
     }
 
     if (writer != NULL) {
-        delete(writer);
+        delete writer;
     }
 
     if (reader != NULL) {
         reader->Shutdown();
-        delete(reader);
+        delete reader;
     }
 
     if (reader_listener != NULL) {
-        delete(reader_listener);
+        delete reader_listener;
     }
 
     std::cerr << "[Info] Finishing test..." <<std::endl;
@@ -1517,7 +1517,7 @@ class LatencyListener : public IMessagingCB
 
         if (_reader != NULL) {
             _reader->Shutdown();
-            delete(_reader);
+            delete _reader;
         }
     }
 
@@ -2093,25 +2093,25 @@ int perftest_cpp::RunPublisher()
     }
 
     if (writer != NULL) {
-        delete(writer);
+        delete writer;
     }
 
     if (announcement_reader_listener != NULL) {
-        delete(announcement_reader_listener);
+        delete announcement_reader_listener;
     }
 
     if (reader_listener != NULL) {
-        delete(reader_listener);
+        delete reader_listener;
     }
 
     if (reader != NULL) {
         reader->Shutdown();
-        delete(reader);
+        delete reader;
     }
 
     if (announcement_reader != NULL) {
         announcement_reader->Shutdown();
-        delete(announcement_reader);
+        delete announcement_reader;
     }
 
     if (_testCompleted) {


### PR DESCRIPTION
This pull request is coming from the issue #111 . When the pull request is merged into "master" the issue will be [resolved, closed, fixed] #111 

**Initial Problem**

Running Clang Static Analyzer, we found a logic error as follow:

In rtiperftest/srcCpp/RTIDDSImpl.cxx:1684.
Possible call to NULL pointer.

```
RTIDynamicDataSubscriber(DDSDataReader *reader): _message()
{
    _reader = DDSDynamicDataReader::narrow(reader); //fail -> _reader = NULL
    if (_reader == NULL) {
        fprintf(stderr,"DDSDynamicDataReader::narrow(reader) error.\n");
        // throw runtime_error exception
    }
    _data_idx = 0;
    _no_data = false;

    // null listener means using receive thread
    if (_reader->get_listener() == NULL) { //Call to NULL pointer FAIL
        ...
        ...
    }
}

```
If `DDSDynamicDataReader::narrow(reader)` fails, and `return NULL`, a call to `NULL` pointer will be done for `_reader->get_listener()` where `_reader` will be `NULL`, ending with a segmentation fault.

**Solution**
 Throwing an exception each time the function `narrow` is called by a constructor, calling the shutdown function before.

**New problem**
When a function called by `Publisher()` or `Subscriber()` fails, a `return` is done without destroying any local variables, some of them created with `alloc` or `new`.

```
    // create latency pong _writer
    _writer = _MessagingImpl->CreateWriter(LATENCY_TOPIC_NAME);

    if (_writer == NULL) {
        fprintf(stderr, "Problem creating latency _writer.\n");
        return -1;
    }
```
**Solution**
All these variables have been moved as `private` inside of `perftest_cpp.h` with their corresponding destructor sentence.

This came up with a dependencies problem, where these new variables inside of perftest_cpp.h were objects of classes defined on perftest_publisher.cxx 
We decided to follow the standard way and create new files with these classes.
