### PR TITLE
Adding shmem unregister to shutdown function for Micro.

### DIFF
--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -112,6 +112,9 @@ void RTIDDSImpl<T>::Shutdown()
         if (!registry->unregister("wh", NULL, NULL)) {
             //printf("failed to unregister wh\n");
         }
+        if (!registry->unregister("_shmem", NULL, NULL)) {
+            //printf("failed to unregister _shmem\n");
+        }
       #ifdef RTI_SECURE_PERFTEST
         if (!SECCORE_SecurePluginFactory::unregister_suite(
                     registry,

--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -112,6 +112,11 @@ void RTIDDSImpl<T>::Shutdown()
         if (!registry->unregister("wh", NULL, NULL)) {
             //printf("failed to unregister wh\n");
         }
+        /*
+         * Since Shared Memory is only aviable for Micro 3.0.0 the unregister
+         * call would fail for previous versions. But it's ok if the unregister
+         * call fails since would not affect the execution.
+         */
         if (!registry->unregister("_shmem", NULL, NULL)) {
             //printf("failed to unregister _shmem\n");
         }

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -54,6 +54,13 @@ What's New in Master
 What's Fixed in Master
 ~~~~~~~~~~~~~~~~~~~~~~
 
+Error using Micro with SHMEM when the test finalize
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An error using *RTI Perftest* for micro 3.0.0 has been solved by unregistering
+'_shmem' before finalize_instance().
+
+
 Improve message when NDDSHOME/RTIMEHOME paths are not reachable (#222)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -54,11 +54,12 @@ What's New in Master
 What's Fixed in Master
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Error using Micro with SHMEM when the test finalize
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error finalizing the application when using `SHMEM` for *RTI Connext DDS Micro* (#234)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-An error using *RTI Perftest* for micro 3.0.0 has been solved by unregistering
-'_shmem' before finalize_instance().
+When using *RTI Connext DDS Micro* and setting the transport to `SHMEM` an error
+would appear at the end of the test in both publisher and subscriber by the time
+he `finalize_instance()` function is called. This errors has been resolved.
 
 
 Improve message when NDDSHOME/RTIMEHOME paths are not reachable (#222)


### PR DESCRIPTION
This pull request is coming from the issue #234 . When the pull request is merged into "master" the issue will be fixed #234 
