### PR TITLE
ZeroCopy is checked before assuming that Asynchronous publisher is used

### DIFF
--- a/srcCpp/RTIDDSImpl.cxx
+++ b/srcCpp/RTIDDSImpl.cxx
@@ -354,7 +354,8 @@ std::string RTIDDSImpl<T>::PrintConfiguration()
     // Asynchronous Publishing
     if (_PM->get<bool>("pub")) {
         stringStream << "\tAsynchronous Publishing: ";
-        if (_isLargeData || _PM->get<bool>("asynchronous")) {
+        if ((_isLargeData || _PM->get<bool>("asynchronous"))
+                && !_PM->get<bool>("zerocopy")) {
             stringStream << "Yes\n";
             stringStream << "\tFlow Controller: "
                          << _PM->get<std::string>("flowController")

--- a/srcCpp03/RTIDDSImpl.cxx
+++ b/srcCpp03/RTIDDSImpl.cxx
@@ -360,7 +360,8 @@ std::string RTIDDSImpl<T>::PrintConfiguration()
     // Dynamic Data
     if (_PM->get<bool>("pub")) {
         stringStream << "\tAsynchronous Publishing: ";
-        if (_isLargeData || _PM->get<bool>("asynchronous")) {
+        if ((_isLargeData || _PM->get<bool>("asynchronous"))
+                && !_PM->get<bool>("zerocopy")) {
             stringStream << "Yes\n";
             stringStream << "\tFlow Controller: "
                          << _PM->get<std::string>("flowController")

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -121,7 +121,7 @@ side in *RTI Perftest* when compiling against *RTI Connext DDS Micro* was not
 set correctly, and it would not account for the extra sample used to skip the
 *CFTs*.
 
-Summary displays *Asynchronous publishing* active when using *Zero-Copy* and *Large Data* (#247)
+Summary displays *Asynchronous publishing* active when using *Zero-Copy* and *Large Data* (#246)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Fixed issue where *RTI Perftest* would present in the summary of the *Publisher*

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -54,14 +54,6 @@ What's New in Master
 What's Fixed in Master
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Incorrect Asynchronous Publisher information when ZeroCopy is used (#247)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Asynchronous Publisher is not used when ZeroCopy is enable since the actual
-size of the sample cannot be large data. The Message information does not take
-into account if ZeroCopy is used and print an incorrect information. This
-behavior has been fix.
-
 Error finalizing the application when using `SHMEM` for *RTI Connext DDS Micro* (#234)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -128,6 +120,18 @@ The value to `max_instances` assigned to the resouce limits in the *DataReader*
 side in *RTI Perftest* when compiling against *RTI Connext DDS Micro* was not
 set correctly, and it would not account for the extra sample used to skip the
 *CFTs*.
+
+Summary displays *Asynchronous publishing* active when using *Zero-Copy* and *Large Data* (#247)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Fixed issue where *RTI Perftest* would present in the summary of the *Publisher*
+side the *Asynchronous Publishing* set to *true* regardless on if the test was
+using *Zero-Copy* or not.
+
+When using *Zero-Copy*, the size of the message being sent will always be
+constant, independent on the size of the sample being sent, as it is just a
+reference to where the sample is stored in memory.
+This means that *Asynchronous Publishing* is not needed in any case.
 
 Release Notes 3.0
 -----------------

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -54,6 +54,14 @@ What's New in Master
 What's Fixed in Master
 ~~~~~~~~~~~~~~~~~~~~~~
 
+Incorrect Asynchronous Publisher information when ZeroCopy is used (#247)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Asynchronous Publisher is not used when ZeroCopy is enable since the actual
+size of the sample cannot be large data. The Message information does not take
+into account if ZeroCopy is used and print an incorrect information. This
+behavior has been fix.
+
 Error finalizing the application when using `SHMEM` for *RTI Connext DDS Micro* (#234)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This pull request is coming from the issue #246 . When the pull request is merged into "master" the issue will be fixed #246
