### PR TITLE
Fix incorrect checks when discovering readers/writer in multipub/sub tests (Related to #261)

### DIFF
--- a/srcCpp/perftest_publisher.cxx
+++ b/srcCpp/perftest_publisher.cxx
@@ -1048,7 +1048,8 @@ int perftest_cpp::Subscriber()
             _PM.get<int>("numPublishers"));
     fflush(stderr);
     reader->WaitForWriters(_PM.get<int>("numPublishers"));
-    writer->WaitForReaders(_PM.get<int>("numPublishers"));
+    // In a multi publisher test, only the first publisher will have a reader.
+    writer->WaitForReaders(1);
     announcement_writer->WaitForReaders(_PM.get<int>("numPublishers"));
 
     /*
@@ -1843,7 +1844,7 @@ int perftest_cpp::Publisher()
     writer->WaitForReaders(_PM.get<int>("numSubscribers"));
     // Only publisher with ID 0 will have a reader.
     if (reader != NULL) {
-        reader->waitForWriters(_PM.get<int>("numSubscribers"));
+        reader->WaitForWriters(_PM.get<int>("numSubscribers"));
     }
     announcement_reader->WaitForWriters(_PM.get<int>("numSubscribers"));
 

--- a/srcCpp/perftest_publisher.cxx
+++ b/srcCpp/perftest_publisher.cxx
@@ -1841,7 +1841,10 @@ int perftest_cpp::Publisher()
             _PM.get<int>("numSubscribers"));
     fflush(stderr);
     writer->WaitForReaders(_PM.get<int>("numSubscribers"));
-    reader->WaitForWriters(_PM.get<int>("numSubscribers"));
+    // Only publisher with ID 0 will have a reader.
+    if (reader != NULL) {
+        reader->waitForWriters(_PM.get<int>("numSubscribers"));
+    }
     announcement_reader->WaitForWriters(_PM.get<int>("numSubscribers"));
 
     // We have to wait until every Subscriber sends an announcement message

--- a/srcCpp03/perftest_publisher.cxx
+++ b/srcCpp03/perftest_publisher.cxx
@@ -1625,7 +1625,10 @@ int perftest_cpp::RunPublisher()
               << " subscribers ..."
               << std::endl;
     writer->waitForReaders(_PM.get<int>("numSubscribers"));
-    reader->waitForWriters(_PM.get<int>("numSubscribers"));
+    // Only publisher with ID 0 will have a reader.
+    if (reader != NULL) {
+        reader->waitForWriters(_PM.get<int>("numSubscribers"));
+    }
     announcement_reader->waitForWriters(_PM.get<int>("numSubscribers"));
 
     // We have to wait until every Subscriber sends an announcement message

--- a/srcCpp03/perftest_publisher.cxx
+++ b/srcCpp03/perftest_publisher.cxx
@@ -1022,7 +1022,8 @@ int perftest_cpp::RunSubscriber()
               << " publishers ..."
               << std::endl;
     reader->waitForWriters(_PM.get<int>("numPublishers"));
-    writer->waitForReaders(_PM.get<int>("numPublishers"));
+    // In a multi publisher test, only the first publisher will have a reader.
+    writer->waitForReaders(1);
     announcement_writer->waitForReaders(_PM.get<int>("numPublishers"));
 
     /*

--- a/srcCs/perftest_publisher.cs
+++ b/srcCs/perftest_publisher.cs
@@ -2228,7 +2228,10 @@ namespace PerformanceTest {
 
             Console.Error.Write("Waiting to discover {0} subscribers ...\n", _NumSubscribers);
             writer.WaitForReaders(_NumSubscribers);
-            reader.WaitForWriters(_NumSubscribers);
+            // Only publisher with ID 0 will have a reader.
+            if (reader != null) {
+                reader.WaitForWriters(_NumSubscribers);
+            }
             announcement_reader.WaitForWriters(_NumSubscribers);
 
             // We have to wait until every Subscriber sends an announcement message

--- a/srcCs/perftest_publisher.cs
+++ b/srcCs/perftest_publisher.cs
@@ -1748,7 +1748,8 @@ namespace PerformanceTest {
             // Synchronize with publishers
             Console.Error.Write("Waiting to discover {0} publishers ...\n", _NumPublishers);
             reader.WaitForWriters(_NumPublishers);
-            writer.WaitForReaders(_NumPublishers);
+            // In a multi publisher test, only the first publisher will have a reader.
+            writer.WaitForReaders(1);
             announcement_writer.WaitForReaders(_NumPublishers);
 
             // Send announcement message

--- a/srcJava/com/rti/perftest/harness/PerfTest.java
+++ b/srcJava/com/rti/perftest/harness/PerfTest.java
@@ -958,7 +958,8 @@ public final class PerfTest {
         // Synchronize with publishers
         System.err.printf("Waiting to discover %1$d publishers ...\n", _numPublishers);
         reader.waitForWriters(_numPublishers);
-        writer.waitForReaders(_numPublishers);
+        // In a multi publisher test, only the first publisher will have a reader.
+        writer.waitForReaders(1);
         announcement_writer.waitForReaders(_numPublishers);
 
         // Announcement message that will be used by the announcement_writer

--- a/srcJava/com/rti/perftest/harness/PerfTest.java
+++ b/srcJava/com/rti/perftest/harness/PerfTest.java
@@ -1176,7 +1176,10 @@ public final class PerfTest {
 
         System.err.printf("Waiting to discover %1$d subscribers ...\n", _numSubscribers);
         writer.waitForReaders(_numSubscribers);
-        reader.waitForWriters(_numSubscribers);
+        // Only publisher with ID 0 will have a reader.
+        if (reader != null) {
+            reader.waitForWriters(_numSubscribers);
+        }
         announcement_reader.waitForWriters(_numSubscribers);
 
         // We have to wait until every Subscriber sends an announcement message


### PR DESCRIPTION
This pull request is coming from the issue #261.


