### PR TITLE
The `RTI_LANGUAGE_CPP_MODERN` flag is not correctly when using the build.sh script (#322)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -417,7 +417,6 @@ function additional_defines_calculation()
     fi
 
     if [ "${1}" = "CppModern" ]; then
-        echo PATATA
         additional_defines=${additional_defines}" DRTI_LANGUAGE_CPP_MODERN"
     fi
 

--- a/build.sh
+++ b/build.sh
@@ -408,7 +408,7 @@ function additional_defines_calculation()
         additional_defines=${additional_defines}" DRTI_CUSTOM_TYPE_FLATDATA="${custom_type_flat}" DRTI_CUSTOM_TYPE_FILE_NAME_SUPPORT="${custom_type_file_name_support}
     fi
 
-    if [ "${1}" = "CPPtraditional" ]; then
+    if [ "${1}" = "CppTraditional" ]; then
         additional_defines=${additional_defines}" DRTI_LANGUAGE_CPP_TRADITIONAL"
 
         if [ "${RTI_PERFTEST_NANO_CLOCK}" == "1" ]; then
@@ -416,7 +416,8 @@ function additional_defines_calculation()
         fi
     fi
 
-    if [ "${1}}" = "CPPmodern" ]; then
+    if [ "${1}" = "CppModern" ]; then
+        echo PATATA
         additional_defines=${additional_defines}" DRTI_LANGUAGE_CPP_MODERN"
     fi
 
@@ -608,7 +609,7 @@ function build_cpp()
     fi
 
     check_flatData_zeroCopy_available
-    additional_defines_calculation "CPPtraditional"
+    additional_defines_calculation "CppTraditional"
 
     additional_header_files="${additional_header_files_custom_type} \
         RTIRawTransportImpl.h \
@@ -924,7 +925,7 @@ function build_cpp03()
 {
     copy_src_cpp_common
     check_flatData_zeroCopy_available
-    additional_defines_calculation "CPPModern"
+    additional_defines_calculation "CppModern"
 
     additional_header_files=" \
         ThreadPriorities.h \

--- a/srcDoc/release_notes.rst
+++ b/srcDoc/release_notes.rst
@@ -304,6 +304,14 @@ architectures.
 
 This issue has been resolved.
 
+The `RTI_LANGUAGE_CPP_MODERN` flag is not correctly when using the build.sh script (#322)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An issue has been resolved in the `build.sh` script that would cause the
+`RTI_LANGUAGE_CPP_MODERN` define flag not to be propagated correctly when compiling.
+This issue was not causing a bug or a wrong behavior in previous versions of
+*RTI Perftest*.
+
 Release Notes 3.0
 -----------------
 


### PR DESCRIPTION
This pull request is coming from the issue #322.